### PR TITLE
fix for Object.noSuchMethod

### DIFF
--- a/lib/pdf_render_widgets.dart
+++ b/lib/pdf_render_widgets.dart
@@ -259,7 +259,7 @@ class _PdfPageViewState extends State<PdfPageView> {
 
     final docLoaderState = _getPdfDocumentLoaderState();
     _size = docLoaderState?._getPageSize(widget.pageNumber);
-    _doc = widget.pdfDocument ?? docLoaderState._doc;
+    _doc = widget.pdfDocument ?? docLoaderState?._doc;
     if (_doc == null) {
       _page = null;
       if (mounted) {
@@ -309,7 +309,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     }
   }
 
-  _PdfDocumentLoaderState _getPdfDocumentLoaderState() => context.ancestorStateOfType(const TypeMatcher<_PdfDocumentLoaderState>());
+  _PdfDocumentLoaderState _getPdfDocumentLoaderState() => context?.ancestorStateOfType(const TypeMatcher<_PdfDocumentLoaderState>());
 
   void _release() {
     _doc = null;


### PR DESCRIPTION
If you put the pdf pages in a TabBarView when switching from one tap to the second most next tab you will get such error, because the context will already be gone by then. those two null checks will fix that