### PR TITLE
Fix allowAntialiasingIOS

### DIFF
--- a/lib/src/interfaces/pdf_render.dart
+++ b/lib/src/interfaces/pdf_render.dart
@@ -218,5 +218,6 @@ abstract class PdfPageImageTexture {
     double? fullWidth,
     double? fullHeight,
     bool backgroundFill = true,
+    bool allowAntialiasingIOS = true,
   });
 }


### PR DESCRIPTION
Issue https://github.com/espresso3389/flutter_pdf_render/issues/29 still persists today and the fix (that was implemented for 0.69.0) has partially disapeared in the commit history (the version 0.69.0 in the pub repo WORKS, but is is different than the commit https://github.com/espresso3389/flutter_pdf_render/commit/1f30bd5ce7cd4eac34b7ab6933c202bdc9559a4f who DOES NOT WORK).

Since 1.0.0 we cannot use the `allowAntialiasingIOS` again, even though the parameter still exist in the internal code.

This PR adds back a way for users to disallow antialiasing for the iOS platform using the `allowAntialiasingIOS` parameter.
