### PR TITLE
Added parameter panAxis from InteractiveViewer

### DIFF
--- a/lib/pdf_render_widgets.dart
+++ b/lib/pdf_render_widgets.dart
@@ -751,6 +751,9 @@ class PdfViewerParams {
 
   /// Scrolling direction.
   final Axis scrollDirection;
+  
+  // See [InteractiveViewer] for more info.
+  final PanAxis panAxis;
 
   /// See [InteractiveViewer] for more info.
   final bool alignPanAxis;
@@ -796,6 +799,7 @@ class PdfViewerParams {
     this.buildPageOverlay,
     this.pageDecoration,
     this.scrollDirection = Axis.vertical,
+    this.panAxis = PanAxis.free,
     this.alignPanAxis = false,
     this.boundaryMargin = EdgeInsets.zero,
     this.maxScale = 20,
@@ -817,6 +821,7 @@ class PdfViewerParams {
     BuildPageContentFunc? buildPageOverlay,
     BoxDecoration? pageDecoration,
     Axis? scrollDirection,
+    PanAxis? panAxis,
     bool? alignPanAxis,
     EdgeInsets? boundaryMargin,
     bool? panEnabled,
@@ -836,6 +841,7 @@ class PdfViewerParams {
         buildPageOverlay: buildPageOverlay ?? this.buildPageOverlay,
         pageDecoration: pageDecoration ?? this.pageDecoration,
         scrollDirection: scrollDirection ?? this.scrollDirection,
+        panAxis: panAxis ?? this.panAxis,
         alignPanAxis: alignPanAxis ?? this.alignPanAxis,
         boundaryMargin: boundaryMargin ?? this.boundaryMargin,
         panEnabled: panEnabled ?? this.panEnabled,
@@ -861,6 +867,7 @@ class PdfViewerParams {
         other.buildPageOverlay == buildPageOverlay &&
         other.pageDecoration == pageDecoration &&
         other.scrollDirection == scrollDirection &&
+        other.panAxis == panAxis &&
         other.alignPanAxis == alignPanAxis &&
         other.boundaryMargin == boundaryMargin &&
         other.panEnabled == panEnabled &&
@@ -881,6 +888,8 @@ class PdfViewerParams {
         buildPagePlaceholder.hashCode ^
         buildPageOverlay.hashCode ^
         pageDecoration.hashCode ^
+        scrollDirection.hashCode ^
+        panAxis.hashCode ^
         scrollDirection.hashCode ^
         alignPanAxis.hashCode ^
         boundaryMargin.hashCode ^
@@ -1164,6 +1173,7 @@ class PdfViewerState extends State<PdfViewer>
         return InteractiveViewer(
           transformationController: _controller,
           constrained: false,
+          panAxis: widget.params?.panAxis ?? PanAxis.free,
           alignPanAxis: widget.params?.alignPanAxis ?? false,
           boundaryMargin: widget.params?.boundaryMargin ?? EdgeInsets.zero,
           minScale: widget.params?.minScale ?? 0.8,


### PR DESCRIPTION
alignPanAxis from InteractiveViewer is deprecated, the new one is panAxis with the Type PanAxis (an enum). I added the new one everywhere where the old one was (without touching the deprecated one, so it won't be a breaking change).

Would be very nice if you could accept this pull request, currently I'm using for my project a modified source file from your library.

The benefit of this addition is, that one will be able to set PanAxis.aligned, which allow to scroll either horizontal or vertical, but not diagonal. Or to set only vertical, only horizontal.

With the div should be very clear what it does

Please write if you have any questions about it.