### PR TITLE
Update for build.gradle (Issue #128)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace("jp.espresso3389.pdf_render")
+    }
+    
     compileSdkVersion 31
 
     sourceSets {


### PR DESCRIPTION
added namespace to build.gradle for compatibility reasons with breaking changes in agp version 8