### PR TITLE
Fix js instance memory leak when close PDFViewer

### DIFF
--- a/lib/pdf_render_widgets.dart
+++ b/lib/pdf_render_widgets.dart
@@ -1155,6 +1155,7 @@ class PdfViewerState extends State<PdfViewer>
   void dispose() {
     _cancelLastRealSizeUpdate();
     _releasePages();
+    _releaseDocument();
     _handlePendedPageDisposes();
     _controller.removeListener(_determinePagesToShow);
     _controller._setViewerState(null);
@@ -1192,6 +1193,11 @@ class PdfViewerState extends State<PdfViewer>
     }
     _pendedPageDisposes.addAll(_pages!);
     _pages = null;
+  }
+
+  void _releaseDocument() {
+    _doc?.dispose();
+    _doc = null;
   }
 
   void _handlePendedPageDisposes() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.7.1
+  js: ^0.6.7
   plugin_platform_interface: ^2.1.8
   vector_math: ^2.1.4
 


### PR DESCRIPTION
## Desc 

- Fix js instance memory leak when close PDFViewer


![Screenshot 2024-05-16 at 16 06 44](https://github.com/espresso3389/flutter_pdf_render/assets/80730648/6bcfae62-d1eb-4bc1-80d9-f985974b62db)


## Solution

- Dispose `PDFDocument` when PDFViewer disposed