### PR TITLE
Fix Null Check Operator Error on Null Value

### DIFF
--- a/lib/pdf_render_widgets.dart
+++ b/lib/pdf_render_widgets.dart
@@ -201,6 +201,7 @@ class PdfDocumentLoaderState extends State<PdfDocumentLoader> {
 
   void _setPageSize(int pageNumber, Size? size) {
     _lastPageSize = size;
+    if (_doc == null) return;
     if (pageNumber > 0 && pageNumber <= _doc!.pageCount) {
       if (_cachedPageSizes == null ||
           _cachedPageSizes?.length != _doc!.pageCount) {


### PR DESCRIPTION
Adds a null check to prevent errors when instantiating the class. Previously, the code used the null check operator (!) on a value that could be null, causing runtime failures. This fix ensures that the code handles null values safely and prevents initialization issues.